### PR TITLE
Fix error in first import of DB

### DIFF
--- a/cmd/dbimport/main.go
+++ b/cmd/dbimport/main.go
@@ -38,14 +38,16 @@ func migrateDatabase(db *sql.DB) {
 		log.Fatal(err)
 	}
 	// TODO: Change this for production
-	migrator, err := migrate.NewWithDatabaseInstance("file://db/migrations", "postgres", driver)
+	migrator, err := migrate.NewWithDatabaseInstance("file://../../db/migrations", "postgres", driver)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	err = migrator.Up()
-	if err != migrate.ErrNoChange {
-		log.Fatal(err)
+	if err != nil {
+		if err != migrate.ErrNoChange {
+			log.Fatal(err)
+		}
 	}
 
 }


### PR DESCRIPTION
Adds a check in the end of the creation of the DB scripts to avoid always failing first time they were executing.