### PR TITLE
Add API version prefix to the endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,22 +37,22 @@ $ go run cmd/server/main.go
 ### Endpoints of the API
 
 ```
-URL: /apps
+URL: /v1/apps
 RESPONSE: JSON with all the apps
 
-URL: /apps/:app
+URL: /v1/apps/:app
 RESPONSE: JSON with a specific 'app'
 
-URL: /apps/:app/:appVersion/resources
+URL: /v1/apps/:app/:appVersion/resources
 RESPONSE: JSON with all the resources for a specific 'version' of an 'app'
 
-URL: /resources
+URL: /v1/resources
 RESPONSE: JSON with all the resources
 
-URL: /resources/:kind/:app/:appVersion
+URL: /v1/resources/:kind/:app/:appVersion
 RESPONSE: JSON with the latest version of the 'kind' of resource for a specific 'version' of an 'app' 
 
-URL: /resources/:kind/:app/:appVersion/:version
+URL: /v1/resources/:kind/:app/:appVersion/:version
 RESPONSE: JSON with the specific 'version' of the 'kind' of resource for a specific 'version' of an 'app' 
 ```
 

--- a/web/router.go
+++ b/web/router.go
@@ -25,14 +25,22 @@ func NewRouterWithLogger(logger *log.Logger) http.Handler {
 func registerOn(router *httprouter.Router, logger *log.Logger) {
 	h := NewHandlerRepository(logger)
 
+	router.GET("/v1/resources", h.retrieveAllResourcesHandler)
 	router.GET("/resources", h.retrieveAllResourcesHandler)
 
+	router.GET("/v1/resources/:kind/:app/:appVersion", h.retrieveOneResourcesHandler)
 	router.GET("/resources/:kind/:app/:appVersion", h.retrieveOneResourcesHandler)
+
+	router.GET("/v1/resources/:kind/:app/:appVersion/:version", h.retrieveOneResourceByVersionHandler)
 	router.GET("/resources/:kind/:app/:appVersion/:version", h.retrieveOneResourceByVersionHandler)
 
+	router.GET("/v1/apps", h.retrieveAllAppsHandler)
 	router.GET("/apps", h.retrieveAllAppsHandler)
 
+	router.GET("/v1/apps/:app", h.retrieveOneAppHandler)
 	router.GET("/apps/:app", h.retrieveOneAppHandler)
+
+	router.GET("/v1/apps/:app/:appVersion/resources", h.retrieveAllResourcesFromAppHandler)
 	router.GET("/apps/:app/:appVersion/resources", h.retrieveAllResourcesFromAppHandler)
 
 	router.GET("/health", h.healthCheckHandler)

--- a/web/web_apps_test.go
+++ b/web/web_apps_test.go
@@ -8,58 +8,81 @@ import (
 )
 
 var _ = Describe("HTTP API for apps", func() {
-	Context("GET /apps", func() {
+	Context("API V1 returns the same than legacy", func() {
+		It("in /apps", func() {
+			responseV1 := doGetRequest("/v1/apps")
+			responseLegacy := doGetRequest("/apps")
+
+			Expect(responseV1).To(Equal(responseLegacy))
+		})
+
+		It("in /apps/:name", func() {
+			responseV1 := doGetRequest("/v1/apps/aws-fargate")
+			responseLegacy := doGetRequest("/apps/aws-fargate")
+
+			Expect(responseV1).To(Equal(responseLegacy))
+		})
+
+		It("in /apps/:name/:appVersion/resources", func() {
+			responseV1 := doGetRequest("/v1/apps/aws-fargate/1.0.0/resources")
+			responseLegacy := doGetRequest("/apps/aws-fargate/1.0.0/resources")
+
+			Expect(responseV1).To(Equal(responseLegacy))
+		})
+	})
+
+	Context("GET /v1/apps", func() {
 		It("returns OK", func() {
-			response := doGetRequest("/apps")
+			response := doGetRequest("/v1/apps")
 
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 		})
 
 		It("returns an JSON response", func() {
-			response := doGetRequest("/apps")
+			response := doGetRequest("/v1/apps")
 
 			Expect(response.Header.Get("Content-Type"), "application/json")
 		})
 	})
 
-	Context("GET /app/:name", func() {
+	Context("GET /v1/apps/:name", func() {
 		It("returns OK", func() {
-			response := doGetRequest("/apps/aws-fargate")
+			response := doGetRequest("/v1/apps/aws-fargate")
 
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 		})
 
 		It("returns an JSON response", func() {
-			response := doGetRequest("/apps/aws-fargate")
+			response := doGetRequest("/v1/apps/aws-fargate")
 
 			Expect(response.Header.Get("Content-Type"), "application/json")
 		})
 
 		Context("when name is not found", func() {
 			It("returns a NOTFOUND", func() {
-				response := doGetRequest("/apps/non-existent")
+				response := doGetRequest("/v1/apps/non-existent")
 
 				Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 			})
 		})
 	})
 
-	Context("GET /apps/:name/:appVersion/resources", func() {
+	Context("GET /v1/apps/:name/:appVersion/resources", func() {
 		It("returns OK", func() {
-			response := doGetRequest("/apps/aws-fargate/1.0.0/resources")
+			response := doGetRequest("/v1/apps/aws-fargate/1.0.0/resources")
 
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 		})
 
 		It("returns an JSON response", func() {
-			response := doGetRequest("/apps/aws-fargate/1.0.0/resources")
+			response := doGetRequest("/v1/apps/aws-fargate/1.0.0/resources")
 
 			Expect(response.Header.Get("Content-Type"), "application/json")
 		})
 
 		Context("when name is not found", func() {
 			It("returns a NOTFOUND", func() {
-				response := doGetRequest("/apps/non-existent/resources")
+				response := doGetRequest("/v1/apps/non-existent/resources")
 
 				Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 			})
@@ -67,7 +90,7 @@ var _ = Describe("HTTP API for apps", func() {
 
 		Context("when app version is not found", func() {
 			It("returns a NOTFOUND", func() {
-				response := doGetRequest("/apps/aws-fargate/1.3/resources")
+				response := doGetRequest("/v1/apps/aws-fargate/1.3/resources")
 
 				Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 			})

--- a/web/web_resources_test.go
+++ b/web/web_resources_test.go
@@ -8,36 +8,59 @@ import (
 )
 
 var _ = Describe("HTTP API for resources", func() {
-	Context("GET /resources", func() {
+	Context("API V1 returns the same than legacy", func() {
+		It("in /resources", func() {
+			responseV1 := doGetRequest("/v1/resources")
+			responseLegacy := doGetRequest("/resources")
+
+			Expect(responseV1).To(Equal(responseLegacy))
+		})
+
+		It("in /resources/:kind/:app/:appVersion", func() {
+			responseV1 := doGetRequest("/v1/resources/Description/aws-fargate/1.0.0")
+			responseLegacy := doGetRequest("/resources/Description/aws-fargate/1.0.0")
+
+			Expect(responseV1).To(Equal(responseLegacy))
+		})
+
+		It("in /resources/:kind/:app/:appVersion/:version", func() {
+			responseV1 := doGetRequest("/v1/resources/Description/aws-fargate/1.0.0/2.0.0")
+			responseLegacy := doGetRequest("/resources/Description/aws-fargate/1.0.0/2.0.0")
+
+			Expect(responseV1).To(Equal(responseLegacy))
+		})
+	})
+
+	Context("GET /v1/resources", func() {
 		It("returns OK", func() {
-			response := doGetRequest("/resources")
+			response := doGetRequest("/v1/resources")
 
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 		})
 
 		It("returns an JSON response", func() {
-			response := doGetRequest("/resources")
+			response := doGetRequest("/v1/resources")
 
 			Expect(response.Header.Get("Content-Type"), "application/json")
 		})
 	})
 
-	Context("GET /resources/:kind/:app/:appVersion", func() {
+	Context("GET /v1/resources/:kind/:app/:appVersion", func() {
 		It("returns OK", func() {
-			response := doGetRequest("/resources/Description/aws-fargate/1.0.0")
+			response := doGetRequest("/v1/resources/Description/aws-fargate/1.0.0")
 
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 		})
 
 		It("returns an JSON response", func() {
-			response := doGetRequest("/resources/Description/aws-fargate/1.0.0")
+			response := doGetRequest("/v1/resources/Description/aws-fargate/1.0.0")
 
 			Expect(response.Header.Get("Content-Type"), "application/json")
 		})
 
 		Context("when app is not found", func() {
 			It("returns a NOTFOUND", func() {
-				response := doGetRequest("/resources/Description/non-existent/1.0.0")
+				response := doGetRequest("/v1/resources/Description/non-existent/1.0.0")
 
 				Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 			})
@@ -45,7 +68,7 @@ var _ = Describe("HTTP API for resources", func() {
 
 		Context("when app version is not found", func() {
 			It("returns a NOTFOUND", func() {
-				response := doGetRequest("/resources/resources/Description/aws-fargate/non-existent")
+				response := doGetRequest("/v1/resources/resources/Description/aws-fargate/non-existent")
 
 				Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 			})
@@ -53,29 +76,29 @@ var _ = Describe("HTTP API for resources", func() {
 
 		Context("when kind does not exist", func() {
 			It("returns a NOTFOUND", func() {
-				response := doGetRequest("/resources/non-existent/aws-fargate/1.0.0")
+				response := doGetRequest("/v1/resources/non-existent/aws-fargate/1.0.0")
 
 				Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 			})
 		})
 	})
 
-	Context("GET /resources/:kind/:app/:appVersion/:version", func() {
+	Context("GET /v1/resources/:kind/:app/:appVersion/:version", func() {
 		It("returns OK", func() {
-			response := doGetRequest("/resources/Description/aws-fargate/1.0.0/2.0.0")
+			response := doGetRequest("/v1/resources/Description/aws-fargate/1.0.0/2.0.0")
 
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 		})
 
 		It("returns an JSON response", func() {
-			response := doGetRequest("/resources/Description/aws-fargate/1.0.0/2.0.0")
+			response := doGetRequest("/v1/resources/Description/aws-fargate/1.0.0/2.0.0")
 
 			Expect(response.Header.Get("Content-Type"), "application/json")
 		})
 
 		Context("when app is not found", func() {
 			It("returns a NOTFOUND", func() {
-				response := doGetRequest("/resources/Description/non-existent/1.0.0/1.0.0")
+				response := doGetRequest("/v1/resources/Description/non-existent/1.0.0/1.0.0")
 
 				Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 			})
@@ -83,7 +106,7 @@ var _ = Describe("HTTP API for resources", func() {
 
 		Context("when app version is not found", func() {
 			It("returns a NOTFOUND", func() {
-				response := doGetRequest("/resources/Description/aws-fargate/non-existent/1.0.0")
+				response := doGetRequest("/v1/resources/Description/aws-fargate/non-existent/1.0.0")
 
 				Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 			})
@@ -91,7 +114,7 @@ var _ = Describe("HTTP API for resources", func() {
 
 		Context("when kind does not exist", func() {
 			It("returns a NOTFOUND", func() {
-				response := doGetRequest("/resources/non-existent/aws-fargate/1.0.0/1.0.0")
+				response := doGetRequest("/v1/resources/non-existent/aws-fargate/1.0.0/1.0.0")
 
 				Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 			})
@@ -99,7 +122,7 @@ var _ = Describe("HTTP API for resources", func() {
 
 		Context("when resource version does not exist", func() {
 			It("returns a NOTFOUND", func() {
-				response := doGetRequest("/resources/Description/aws-fargate/1.0.0/5.0.0")
+				response := doGetRequest("/v1/resources/Description/aws-fargate/1.0.0/5.0.0")
 
 				Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 			})


### PR DESCRIPTION
- Added additional endpoints with the 'v1' prefix
- Added tests
- Maintained the endpoints without prefix. They will be deprecated and removed in following months. 